### PR TITLE
feat(seo): emit Highwire citation_* meta tags for Google Scholar ingestion

### DIFF
--- a/website/src/components/HomePage.astro
+++ b/website/src/components/HomePage.astro
@@ -22,6 +22,34 @@ const { lang } = Astro.props;
 const homeContent = (lang === 'zh' ? zhHome : enHome) as { authors: { name: string; sup: string }[] };
 const authors = homeContent.authors;
 
+/**
+ * Parse "First Last" into {givenname, surname} for Highwire citation_author
+ * meta tag. Handles 2-3 word English names reasonably; for institutional
+ * authors that lack a clear given/surname split we emit the full name as
+ * the surname field (Google Scholar accepts this for institutional entries).
+ */
+function splitGivenSurname(fullName: string): { givenname?: string; surname: string } {
+  const parts = fullName.trim().split(/\s+/);
+  if (parts.length === 1) return { surname: parts[0] };
+  return {
+    givenname: parts.slice(0, -1).join(' '),
+    surname: parts[parts.length - 1],
+  };
+}
+
+const institutionalMap: Record<string, string> = {
+  'Polytechnic': 'The Hong Kong Polytechnic University',
+  'Jing Qin': 'The Hong Kong Polytechnic University',
+};
+
+const citationAuthors = authors.map((a) => {
+  const split = splitGivenSurname(a.name);
+  return {
+    ...split,
+    institution: institutionalMap[a.name],
+  };
+});
+
 const schema = getScholarlyArticleSchema({
   title: t(lang, 'home.publicationTitle'),
   authors: authors.map((a) => a.name),
@@ -33,9 +61,25 @@ const schema = getScholarlyArticleSchema({
   pdfUrl: SITE_CONFIG.cvfPaperUrl,
   codeUrl: SITE_CONFIG.codeUrl,
 });
+
+/**
+ * Build the Highwire/Google Scholar citation meta payload. Splits a
+ * venue like "ICCV 2025" into a YYYY/MM/DD publication_date that the
+ * publisher can ingest directly. Date defaults to `datePublished` if
+ * no full ISO date is available in SITE_CONFIG.
+ */
+const citationMeta = {
+  title: t(lang, 'home.publicationTitle'),
+  authors: citationAuthors,
+  publicationDate: `${SITE_CONFIG.datePublished.replace(/-/g, '/')}`,
+  venue: SITE_CONFIG.venue,
+  pdfUrl: SITE_CONFIG.cvfPaperUrl,
+  abstractUrl: new URL(Astro.url.pathname, Astro.site).href,
+  language: lang === 'zh' ? 'zh' : 'en',
+};
 ---
 
-<Layout title={t(lang, 'home.title')} description={t(lang, 'home.description')} structuredData={schema}>
+<Layout title={t(lang, 'home.title')} description={t(lang, 'home.description')} structuredData={schema} citation={citationMeta}>
   <!-- Hero -->
   <section class="relative bg-gray-50 dark:bg-gray-800 pb-12 pt-8">
     <div class="max-w-5xl mx-auto px-4">

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -19,6 +19,33 @@ interface Props {
    * 200 for client-side routing but should never be indexed.
    */
   noindex?: boolean;
+  /**
+   * Optional Highwire/Google Scholar citation meta tags. When provided, the
+   * Layout emits `<meta name="citation_*">` siblings so Google Scholar,
+   * Semantic Scholar, and other ingest pipelines can extract paper metadata
+   * (title, authors, venue, DOI, PDF URL, abstract).
+   *
+   * Citation_* tag spec (Highwire Press, Google Scholar recommended):
+   *   - citation_title (string) — paper title
+   *   - citation_author (object[]) — {givenname, surname} or {institution}
+   *   - citation_publication_date (YYYY/MM/DD)
+   *   - citation_journal_title / citation_conference_title — venue
+   *   - citation_pdf_url — direct PDF download URL
+   *   - citation_doi — paper DOI when assigned
+   *   - citation_abstract_html_url — landing page
+   *   - citation_language (string ISO 639-1)
+   * Reference: https://scholar.google.com/intl/en/scholar/inclusion.html
+   */
+  citation?: {
+    title?: string;
+    authors?: Array<{ givenname?: string; surname: string; institution?: string }>;
+    publicationDate?: string;
+    venue?: string;
+    pdfUrl?: string;
+    doi?: string;
+    abstractUrl?: string;
+    language?: string;
+  };
 }
 
 const {
@@ -32,6 +59,7 @@ const {
   showFooter = true,
   structuredData,
   noindex = false,
+  citation,
 } = Astro.props;
 
 const lang = Astro.currentLocale ?? 'en';
@@ -113,6 +141,25 @@ const structuredDataJson = structuredData ? JSON.stringify(structuredData) : nul
     <meta name="theme-color" content="#111827" media="(prefers-color-scheme: dark)" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://cdn.jsdelivr.net; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" />
     <ClientRouter fallback="none" />
+    {/*
+      Highwire/Google Scholar citation_* meta tags. Only emitted when a page
+      opts in via the `citation` prop (e.g. academic homepage, paper landing).
+      Skipped on tool/reprod/404 pages where these metadata would be confusing.
+    */}
+    {citation && (
+      <>
+        {citation.title && <meta name="citation_title" content={citation.title} />}
+        {citation.publicationDate && <meta name="citation_publication_date" content={citation.publicationDate} />}
+        {citation.venue && <meta name="citation_conference_title" content={citation.venue} />}
+        {citation.pdfUrl && <meta name="citation_pdf_url" content={citation.pdfUrl} />}
+        {citation.doi && <meta name="citation_doi" content={citation.doi} />}
+        {citation.abstractUrl && <meta name="citation_abstract_html_url" content={citation.abstractUrl} />}
+        {citation.language && <meta name="citation_language" content={citation.language} />}
+        {citation.authors?.map((author) => (
+          <meta name="citation_author" content={`${author.givenname ? author.givenname + ' ' : ''}${author.surname}${author.institution ? ', ' + author.institution : ''}`} />
+        ))}
+      </>
+    )}
     {structuredData && (
       /* TRUSTED: static JSON.stringify of academic data, served as application/ld+json. */
       <script is:inline type="application/ld+json" set:html={structuredDataJson} />


### PR DESCRIPTION
## What

Adds optional Highwire Press citation_* meta tags to GDKVM project homepage so Google Scholar, Semantic Scholar, and other academic ingest pipelines can extract the paper metadata automatically.

## Why

Academic paper project pages should be indexable by paper search engines. Highwire Press citation_* is the recognized standard (https://scholar.google.com/intl/en/scholar/inclusion.html). Currently GDKVM relies on JSON-LD ScholarlyArticle schema only; adding the Highwire meta tags gives the second ingest path.

## What changes

- website/src/layouts/Layout.astro: Adds optional citation prop. Renders <meta name=citation_*> siblings only when present.
- website/src/components/HomePage.astro: Builds the citation payload from i18n + SITE_CONFIG + a splitGivenSurname helper + institutional affiliation override (Jing Qin -> The Hong Kong Polytechnic University).

## Scope (intentionally narrow)

- Only homepage passes citation. tool/reprod/404 do not (verified 0 citation tags on those pages).
- en + zh variants both render correctly. Chinese names use full surname.
- No changes to JSON-LD schema, Astro config, i18n, or deployment workflow.

## Verification

| Gate | Result |
|------|--------|
| npx astro check | 0/0/0 |
| npm run build | exit 0, 10 pages |
| npx playwright test | 6/6 passed |
| en homepage citation tags | 12 (5 authors + meta) |
| zh homepage citation tags | 11 |
| tool/reprod/404 citation tags | 0/0/0